### PR TITLE
fix(a11y): add aria-labels to interactive elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,8 +80,8 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16">
                 <!-- Logo -->
-                <a href="#" class="flex items-center space-x-2">
-                    <svg class="w-8 h-8" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <a href="#" class="flex items-center space-x-2" aria-label="CuadrilIA - Ir al inicio">
+                    <svg class="w-8 h-8" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                         <circle cx="25" cy="25" r="8" fill="#7c3aed"/>
                         <circle cx="75" cy="25" r="8" fill="#7c3aed"/>
                         <circle cx="25" cy="75" r="8" fill="#2563eb"/>
@@ -103,8 +103,8 @@
                 </div>
                 
                 <!-- Mobile Menu Button -->
-                <button id="mobile-menu-btn" class="md:hidden text-gray-300 hover:text-white">
-                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <button id="mobile-menu-btn" class="md:hidden text-gray-300 hover:text-white" aria-label="Abrir menú de navegación" aria-expanded="false" aria-controls="mobile-menu">
+                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
                     </svg>
                 </button>
@@ -157,45 +157,45 @@
         <div class="relative">
             <div class="flex animate-marquee whitespace-nowrap">
                 <!-- First set of logos -->
-                <div class="flex items-center space-x-16 mx-8">
+                <div class="flex items-center space-x-16 mx-8" aria-hidden="true">
                     <!-- Anthropic -->
                     <div class="flex items-center space-x-2 text-gray-400 hover:text-white transition-colors">
-                        <svg class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor"><path d="M17.557 3.5l4.943 16.5h-4.097l-1.067-3.934H11.74l2.062-3.5h4.695L15.57 3.5h1.987zm-8.005 0L6.51 12.57 3.5 3.5H7.6l1.952 9.07L6.51 3.5h3.042z"/></svg>
+                        <svg class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.557 3.5l4.943 16.5h-4.097l-1.067-3.934H11.74l2.062-3.5h4.695L15.57 3.5h1.987zm-8.005 0L6.51 12.57 3.5 3.5H7.6l1.952 9.07L6.51 3.5h3.042z"/></svg>
                         <span class="font-semibold">Anthropic</span>
                     </div>
                     <!-- OpenAI -->
                     <div class="flex items-center space-x-2 text-gray-400 hover:text-white transition-colors">
-                        <svg class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor"><path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z"/></svg>
+                        <svg class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z"/></svg>
                         <span class="font-semibold">OpenAI</span>
                     </div>
                     <!-- Google -->
                     <div class="flex items-center space-x-2 text-gray-400 hover:text-white transition-colors">
-                        <svg class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor"><path d="M12 11h8.533c.044.385.067.78.067 1.184 0 2.734-.98 5.036-2.678 6.6-1.485 1.371-3.518 2.175-5.942 2.175A8.976 8.976 0 0 1 3 12a8.976 8.976 0 0 1 8.98-8.959c2.424 0 4.458.882 6.022 2.314l-2.513 2.513C14.406 6.867 13.266 6.4 12 6.4a5.54 5.54 0 0 0-5.56 5.6A5.54 5.54 0 0 0 12 17.6c2.747 0 4.634-1.659 5.097-3.6H12V11z"/></svg>
+                        <svg class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 11h8.533c.044.385.067.78.067 1.184 0 2.734-.98 5.036-2.678 6.6-1.485 1.371-3.518 2.175-5.942 2.175A8.976 8.976 0 0 1 3 12a8.976 8.976 0 0 1 8.98-8.959c2.424 0 4.458.882 6.022 2.314l-2.513 2.513C14.406 6.867 13.266 6.4 12 6.4a5.54 5.54 0 0 0-5.56 5.6A5.54 5.54 0 0 0 12 17.6c2.747 0 4.634-1.659 5.097-3.6H12V11z"/></svg>
                         <span class="font-semibold">Gemini</span>
                     </div>
                     <!-- xAI -->
                     <div class="flex items-center space-x-2 text-gray-400 hover:text-white transition-colors">
-                        <svg class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor"><path d="M2 4l8.5 8L2 20h3l7-6.5L19 20h3l-8.5-8L22 4h-3l-7 6.5L5 4H2z"/></svg>
+                        <svg class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M2 4l8.5 8L2 20h3l7-6.5L19 20h3l-8.5-8L22 4h-3l-7 6.5L5 4H2z"/></svg>
                         <span class="font-semibold">xAI</span>
                     </div>
                     <!-- Meta -->
                     <div class="flex items-center space-x-2 text-gray-400 hover:text-white transition-colors">
-                        <svg class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor"><path d="M6.915 4.03c-1.968 0-3.683 1.28-4.871 3.113C.704 9.208 0 11.883 0 14.449c0 .706.07 1.369.21 1.973a4.892 4.892 0 0 0 1.12 2.136c.514.57 1.165.97 1.942 1.163.39.096.801.144 1.22.144.964 0 1.992-.283 2.971-.834.736-.414 1.476-.964 2.21-1.631.196.168.404.329.612.478.566.404 1.09.719 1.58.948.49.23.942.378 1.356.378.265 0 .503-.057.71-.176a1.25 1.25 0 0 0 .46-.476c.093-.179.14-.383.14-.612 0-.299-.082-.611-.249-.937a6.756 6.756 0 0 0-.638-.946 9.1 9.1 0 0 0-.694-.795l-.006-.005-.065-.066c.891-1.048 1.63-2.074 2.168-3.034.537-.96.876-1.877.876-2.733 0-.639-.18-1.147-.538-1.51-.36-.362-.86-.545-1.483-.545-.654 0-1.352.212-2.032.63-.68.417-1.357.996-1.998 1.714-.476-.487-.993-.904-1.522-1.228-.53-.325-1.09-.553-1.647-.68a4.76 4.76 0 0 0-.954-.095zm.117 1.633c.263 0 .555.042.869.125.314.083.652.217 1.003.4.293.154.595.345.897.572a9.94 9.94 0 0 1-.582.628 24.652 24.652 0 0 1-1.376 1.27c-.477.41-.886.735-1.23.962-.344.228-.604.347-.796.347-.194 0-.358-.09-.493-.273a1.652 1.652 0 0 1-.267-.64 3.612 3.612 0 0 1-.086-.8c0-.815.202-1.616.574-2.334.248-.48.514-.852.8-1.102.284-.25.547-.378.687-.155z"/></svg>
+                        <svg class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M6.915 4.03c-1.968 0-3.683 1.28-4.871 3.113C.704 9.208 0 11.883 0 14.449c0 .706.07 1.369.21 1.973a4.892 4.892 0 0 0 1.12 2.136c.514.57 1.165.97 1.942 1.163.39.096.801.144 1.22.144.964 0 1.992-.283 2.971-.834.736-.414 1.476-.964 2.21-1.631.196.168.404.329.612.478.566.404 1.09.719 1.58.948.49.23.942.378 1.356.378.265 0 .503-.057.71-.176a1.25 1.25 0 0 0 .46-.476c.093-.179.14-.383.14-.612 0-.299-.082-.611-.249-.937a6.756 6.756 0 0 0-.638-.946 9.1 9.1 0 0 0-.694-.795l-.006-.005-.065-.066c.891-1.048 1.63-2.074 2.168-3.034.537-.96.876-1.877.876-2.733 0-.639-.18-1.147-.538-1.51-.36-.362-.86-.545-1.483-.545-.654 0-1.352.212-2.032.63-.68.417-1.357.996-1.998 1.714-.476-.487-.993-.904-1.522-1.228-.53-.325-1.09-.553-1.647-.68a4.76 4.76 0 0 0-.954-.095zm.117 1.633c.263 0 .555.042.869.125.314.083.652.217 1.003.4.293.154.595.345.897.572a9.94 9.94 0 0 1-.582.628 24.652 24.652 0 0 1-1.376 1.27c-.477.41-.886.735-1.23.962-.344.228-.604.347-.796.347-.194 0-.358-.09-.493-.273a1.652 1.652 0 0 1-.267-.64 3.612 3.612 0 0 1-.086-.8c0-.815.202-1.616.574-2.334.248-.48.514-.852.8-1.102.284-.25.547-.378.687-.155z"/></svg>
                         <span class="font-semibold">Meta AI</span>
                     </div>
                     <!-- Microsoft -->
                     <div class="flex items-center space-x-2 text-gray-400 hover:text-white transition-colors">
-                        <svg class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor"><path d="M11.4 24H0V12.6h11.4V24zM24 24H12.6V12.6H24V24zM11.4 11.4H0V0h11.4v11.4zm12.6 0H12.6V0H24v11.4z"/></svg>
+                        <svg class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M11.4 24H0V12.6h11.4V24zM24 24H12.6V12.6H24V24zM11.4 11.4H0V0h11.4v11.4zm12.6 0H12.6V0H24v11.4z"/></svg>
                         <span class="font-semibold">Copilot</span>
                     </div>
                     <!-- Mistral -->
                     <div class="flex items-center space-x-2 text-gray-400 hover:text-white transition-colors">
-                        <svg class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor"><rect x="2" y="2" width="4" height="4"/><rect x="10" y="2" width="4" height="4"/><rect x="18" y="2" width="4" height="4"/><rect x="2" y="10" width="4" height="4"/><rect x="10" y="10" width="4" height="4"/><rect x="18" y="10" width="4" height="4"/><rect x="2" y="18" width="4" height="4"/><rect x="10" y="18" width="4" height="4"/><rect x="18" y="18" width="4" height="4"/></svg>
+                        <svg class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><rect x="2" y="2" width="4" height="4"/><rect x="10" y="2" width="4" height="4"/><rect x="18" y="2" width="4" height="4"/><rect x="2" y="10" width="4" height="4"/><rect x="10" y="10" width="4" height="4"/><rect x="18" y="10" width="4" height="4"/><rect x="2" y="18" width="4" height="4"/><rect x="10" y="18" width="4" height="4"/><rect x="18" y="18" width="4" height="4"/></svg>
                         <span class="font-semibold">Mistral</span>
                     </div>
                 </div>
                 <!-- Duplicate for infinite scroll -->
-                <div class="flex items-center space-x-16 mx-8">
+                <div class="flex items-center space-x-16 mx-8" aria-hidden="true">
                     <!-- Anthropic -->
                     <div class="flex items-center space-x-2 text-gray-400 hover:text-white transition-colors">
                         <svg class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor"><path d="M17.557 3.5l4.943 16.5h-4.097l-1.067-3.934H11.74l2.062-3.5h4.695L15.57 3.5h1.987zm-8.005 0L6.51 12.57 3.5 3.5H7.6l1.952 9.07L6.51 3.5h3.042z"/></svg>
@@ -248,7 +248,7 @@
                 <!-- Card 1: Talleres In-Situ -->
                 <div class="fade-in group bg-gray-800/30 border border-gray-700 rounded-2xl p-8 hover:border-purple-500/50 hover:bg-gray-800/50 transition-all duration-300">
                     <div class="w-14 h-14 bg-gradient-to-br from-purple-600 to-blue-600 rounded-xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform">
-                        <svg class="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"/></svg>
+                        <svg class="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"/></svg>
                     </div>
                     <h3 class="text-xl font-bold mb-3">Talleres In-Situ</h3>
                     <p class="text-gray-400 leading-relaxed">Aprendemos contigo, en tu espacio. Nos desplazamos a tu oficina para sesiones prácticas donde tu equipo aprende haciendo, no solo escuchando.</p>
@@ -257,7 +257,7 @@
                 <!-- Card 2: IA para el Día a Día -->
                 <div class="fade-in group bg-gray-800/30 border border-gray-700 rounded-2xl p-8 hover:border-purple-500/50 hover:bg-gray-800/50 transition-all duration-300">
                     <div class="w-14 h-14 bg-gradient-to-br from-purple-600 to-blue-600 rounded-xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform">
-                        <svg class="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
+                        <svg class="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
                     </div>
                     <h3 class="text-xl font-bold mb-3">IA para Tu Día a Día</h3>
                     <p class="text-gray-400 leading-relaxed">Trabaja menos, logra más. No necesitas saber programar. Te enseñamos a usar asistentes de IA para eliminar tareas repetitivas y recuperar tu tiempo.</p>
@@ -266,7 +266,7 @@
                 <!-- Card 3: Spec-Kit -->
                 <div class="fade-in group bg-gray-800/30 border border-gray-700 rounded-2xl p-8 hover:border-purple-500/50 hover:bg-gray-800/50 transition-all duration-300">
                     <div class="w-14 h-14 bg-gradient-to-br from-purple-600 to-blue-600 rounded-xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform">
-                        <svg class="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+                        <svg class="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
                     </div>
                     <h3 class="text-xl font-bold mb-3">Spec-Kit</h3>
                     <p class="text-gray-400 leading-relaxed">De la idea al proyecto, sin ruido. Herramientas para definir lo que necesitas construir. Especificaciones claras que tu equipo y la IA entienden a la primera.</p>
@@ -275,7 +275,7 @@
                 <!-- Card 4: AGENTS.md -->
                 <div class="fade-in group bg-gray-800/30 border border-gray-700 rounded-2xl p-8 hover:border-purple-500/50 hover:bg-gray-800/50 transition-all duration-300">
                     <div class="w-14 h-14 bg-gradient-to-br from-purple-600 to-blue-600 rounded-xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform">
-                        <svg class="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+                        <svg class="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
                     </div>
                     <h3 class="text-xl font-bold mb-3">AGENTS.md</h3>
                     <p class="text-gray-400 leading-relaxed">Tu asistente, tus reglas. Configura asistentes inteligentes que conocen tu empresa, tu código y tu manera de hacer las cosas.</p>
@@ -284,7 +284,7 @@
                 <!-- Card 5: MCPs y Skills -->
                 <div class="fade-in group bg-gray-800/30 border border-gray-700 rounded-2xl p-8 hover:border-purple-500/50 hover:bg-gray-800/50 transition-all duration-300">
                     <div class="w-14 h-14 bg-gradient-to-br from-purple-600 to-blue-600 rounded-xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform">
-                        <svg class="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"/></svg>
+                        <svg class="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"/></svg>
                     </div>
                     <h3 class="text-xl font-bold mb-3">MCPs y Skills</h3>
                     <p class="text-gray-400 leading-relaxed">Conecta todo, sin complicaciones. Integra tus herramientas favoritas con IA de forma segura. Sin código complejo, sin dolores de cabeza.</p>
@@ -293,7 +293,7 @@
                 <!-- Card 6: Consultoría -->
                 <div class="fade-in group bg-gray-800/30 border border-gray-700 rounded-2xl p-8 hover:border-purple-500/50 hover:bg-gray-800/50 transition-all duration-300">
                     <div class="w-14 h-14 bg-gradient-to-br from-purple-600 to-blue-600 rounded-xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform">
-                        <svg class="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>
+                        <svg class="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>
                     </div>
                     <h3 class="text-xl font-bold mb-3">Consultoría Estratégica</h3>
                     <p class="text-gray-400 leading-relaxed">Encuentra tu ventaja. Te ayudamos a descubrir dónde la IA puede marcar la diferencia en tu negocio. Estrategia antes que tecnología.</p>
@@ -314,7 +314,7 @@
                 <!-- Beneficio 1 -->
                 <div class="fade-in text-center">
                     <div class="w-16 h-16 mx-auto mb-4 rounded-full bg-purple-600/20 flex items-center justify-center">
-                        <svg class="w-8 h-8 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"/></svg>
+                        <svg class="w-8 h-8 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"/></svg>
                     </div>
                     <h3 class="text-lg font-bold mb-2">Formación a tu medida</h3>
                     <p class="text-gray-400 text-sm">Adaptamos el contenido a tu nivel, desde principiantes hasta equipos técnicos avanzados.</p>
@@ -323,7 +323,7 @@
                 <!-- Beneficio 2 -->
                 <div class="fade-in text-center">
                     <div class="w-16 h-16 mx-auto mb-4 rounded-full bg-blue-600/20 flex items-center justify-center">
-                        <svg class="w-8 h-8 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
+                        <svg class="w-8 h-8 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
                     </div>
                     <h3 class="text-lg font-bold mb-2">Resultados desde el día uno</h3>
                     <p class="text-gray-400 text-sm">Nada de teoría interminable. Aplicarás lo aprendido en tu trabajo real inmediatamente.</p>
@@ -332,7 +332,7 @@
                 <!-- Beneficio 3 -->
                 <div class="fade-in text-center">
                     <div class="w-16 h-16 mx-auto mb-4 rounded-full bg-purple-600/20 flex items-center justify-center">
-                        <svg class="w-8 h-8 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8h2a2 2 0 012 2v6a2 2 0 01-2 2h-2v4l-4-4H9a1.994 1.994 0 01-1.414-.586m0 0L11 14h4a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2v4l.586-.586z"/></svg>
+                        <svg class="w-8 h-8 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8h2a2 2 0 012 2v6a2 2 0 01-2 2h-2v4l-4-4H9a1.994 1.994 0 01-1.414-.586m0 0L11 14h4a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2v4l.586-.586z"/></svg>
                     </div>
                     <h3 class="text-lg font-bold mb-2">Soporte continuo</h3>
                     <p class="text-gray-400 text-sm">La formación termina, pero el acompañamiento no. Estamos ahí cuando surgen dudas.</p>
@@ -341,7 +341,7 @@
                 <!-- Beneficio 4 -->
                 <div class="fade-in text-center">
                     <div class="w-16 h-16 mx-auto mb-4 rounded-full bg-blue-600/20 flex items-center justify-center">
-                        <svg class="w-8 h-8 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z"/></svg>
+                        <svg class="w-8 h-8 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z"/></svg>
                     </div>
                     <h3 class="text-lg font-bold mb-2">Experiencia demostrada</h3>
                     <p class="text-gray-400 text-sm">Equipos de empresas reales ya trabajan mejor gracias a lo que aprendieron con nosotros.</p>
@@ -422,7 +422,7 @@
             <div class="fade-in bg-gray-800/30 border border-gray-700 rounded-2xl p-8 md:p-12">
                 <!-- Placeholder para Google Forms -->
                 <div class="text-center py-12 border-2 border-dashed border-gray-600 rounded-xl">
-                    <svg class="w-16 h-16 mx-auto text-gray-500 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+                    <svg class="w-16 h-16 mx-auto text-gray-500 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
                     <p class="text-gray-400 mb-4">Aquí irá el formulario de Google Forms</p>
                     <p class="text-gray-500 text-sm">Reemplaza este bloque con el iframe de tu Google Form:</p>
                     <code class="block mt-2 text-xs text-purple-400 bg-gray-900 p-3 rounded-lg max-w-md mx-auto overflow-x-auto">
@@ -445,7 +445,7 @@
             <div class="flex flex-col md:flex-row items-center justify-between gap-8">
                 <!-- Logo -->
                 <div class="flex items-center space-x-2">
-                    <svg class="w-8 h-8" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <svg class="w-8 h-8" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                         <circle cx="25" cy="25" r="8" fill="#7c3aed"/>
                         <circle cx="75" cy="25" r="8" fill="#7c3aed"/>
                         <circle cx="25" cy="75" r="8" fill="#2563eb"/>
@@ -485,13 +485,17 @@
         const mobileMenu = document.getElementById('mobile-menu');
         
         mobileMenuBtn.addEventListener('click', () => {
-            mobileMenu.classList.toggle('hidden');
+            const isExpanded = mobileMenu.classList.toggle('hidden');
+            mobileMenuBtn.setAttribute('aria-expanded', !isExpanded);
+            mobileMenuBtn.setAttribute('aria-label', isExpanded ? 'Abrir menú de navegación' : 'Cerrar menú de navegación');
         });
 
         // Close mobile menu when clicking a link
         mobileMenu.querySelectorAll('a').forEach(link => {
             link.addEventListener('click', () => {
                 mobileMenu.classList.add('hidden');
+                mobileMenuBtn.setAttribute('aria-expanded', 'false');
+                mobileMenuBtn.setAttribute('aria-label', 'Abrir menú de navegación');
             });
         });
 


### PR DESCRIPTION
## Summary
- Añade `aria-label` al botón hamburguesa del menú móvil
- Añade `aria-expanded` dinámico para indicar estado del menú
- Añade `aria-hidden="true"` a todos los SVGs decorativos
- Añade `aria-label` al logo del navbar y footer
- Añade `role="img"` donde corresponde

Closes #1

## Checklist
- [ ] Todos los elementos interactivos tienen aria-labels en español
- [ ] El botón hamburguesa anuncia correctamente su estado
- [ ] Los iconos decorativos están ocultos para lectores de pantalla