### PR TITLE
feat(ux): add back-to-top button

### DIFF
--- a/index.html
+++ b/index.html
@@ -495,6 +495,18 @@
     </section>
     </main>
 
+    <!-- Back to Top Button -->
+    <button 
+        id="back-to-top" 
+        class="fixed bottom-8 right-8 w-12 h-12 bg-gradient-to-r from-purple-600 to-blue-600 text-white rounded-full shadow-lg opacity-0 invisible transition-all duration-300 hover:scale-110 hover:shadow-xl z-50 flex items-center justify-center"
+        aria-label="Volver arriba"
+        title="Volver arriba"
+    >
+        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18"/>
+        </svg>
+    </button>
+
     <!-- Footer -->
     <footer class="py-12 px-4 border-t border-gray-800">
         <div class="max-w-7xl mx-auto">
@@ -606,6 +618,23 @@
         }, sectionObserverOptions);
 
         sections.forEach(section => sectionObserver.observe(section));
+
+        // Back to top button
+        const backToTopBtn = document.getElementById('back-to-top');
+        
+        window.addEventListener('scroll', () => {
+            if (window.scrollY > 500) {
+                backToTopBtn.classList.remove('opacity-0', 'invisible');
+                backToTopBtn.classList.add('opacity-100', 'visible');
+            } else {
+                backToTopBtn.classList.add('opacity-0', 'invisible');
+                backToTopBtn.classList.remove('opacity-100', 'visible');
+            }
+        });
+
+        backToTopBtn.addEventListener('click', () => {
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+        });
     </script>
 
     <!-- JSON-LD Structured Data -->


### PR DESCRIPTION
## Summary
- Add floating back-to-top button that appears after scrolling 500px
- Smooth scroll animation when clicked
- Gradient style matching brand identity
- Full accessibility support (aria-label, title, keyboard focus)

## Changes
- Added button HTML with proper ARIA attributes
- Added JavaScript for show/hide logic and scroll behavior
- Button uses same gradient as CTAs for visual consistency

Closes #19