### PR TITLE
feat(ux): add visual pause indicator to carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,32 @@
         .nav-link {
             position: relative;
         }
+        
+        /* Carousel pause indicator */
+        .carousel-container {
+            position: relative;
+        }
+        .carousel-pause-indicator {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            background: rgba(124, 58, 237, 0.9);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: none;
+            z-index: 10;
+        }
+        .carousel-container:hover .carousel-pause-indicator {
+            opacity: 1;
+        }
     </style>
 </head>
 <body class="font-sans antialiased">
@@ -203,7 +229,13 @@
     <!-- Logos Marquee -->
     <section class="py-16 border-y border-gray-800 overflow-hidden">
         <p class="text-center text-gray-300 mb-10 text-sm uppercase tracking-widest">Trabajamos con las tecnologías que están cambiando el mundo</p>
-        <div class="relative">
+        <div class="relative carousel-container" role="marquee" aria-label="Carrusel de tecnologías con las que trabajamos">
+            <div class="carousel-pause-indicator" aria-hidden="true">
+                <span class="flex items-center gap-2">
+                    <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M6 4h4v16H6V4zm8 0h4v16h-4V4z"/></svg>
+                    Pausado
+                </span>
+            </div>
             <div class="flex animate-marquee whitespace-nowrap">
                 <!-- First set of logos -->
                 <div class="flex items-center space-x-16 mx-8" aria-hidden="true">


### PR DESCRIPTION
## Summary
- Add visual "Pausado" indicator when hovering over the logo carousel
- Improves UX by clearly communicating that the carousel is paused

## Changes
- Added CSS for pause indicator with fade-in animation
- Added pause icon + text badge centered on carousel
- Added `role="marquee"` for accessibility

Closes #21