### PR TITLE
feat(ux): add initial page loading animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,9 +141,58 @@
         .carousel-container:hover .carousel-pause-indicator {
             opacity: 1;
         }
+        
+        /* Page loading animation */
+        .page-loader {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background-color: #0d1117;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 99999;
+            transition: opacity 0.5s ease, visibility 0.5s ease;
+        }
+        .page-loader.hidden {
+            opacity: 0;
+            visibility: hidden;
+        }
+        .loader-logo {
+            animation: pulse-logo 1.5s ease-in-out infinite;
+        }
+        @keyframes pulse-logo {
+            0%, 100% { transform: scale(1); opacity: 1; }
+            50% { transform: scale(1.1); opacity: 0.8; }
+        }
+        .loader-text {
+            animation: fade-text 1.5s ease-in-out infinite;
+        }
+        @keyframes fade-text {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.5; }
+        }
     </style>
 </head>
 <body class="font-sans antialiased">
+    <!-- Page Loader -->
+    <div id="page-loader" class="page-loader" aria-label="Cargando página">
+        <div class="text-center">
+            <svg class="w-16 h-16 mx-auto loader-logo" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <circle cx="25" cy="25" r="8" fill="#7c3aed"/>
+                <circle cx="75" cy="25" r="8" fill="#7c3aed"/>
+                <circle cx="25" cy="75" r="8" fill="#2563eb"/>
+                <circle cx="75" cy="75" r="8" fill="#2563eb"/>
+                <line x1="25" y1="25" x2="75" y2="25" stroke="#7c3aed" stroke-width="3"/>
+                <line x1="25" y1="75" x2="75" y2="75" stroke="#2563eb" stroke-width="3"/>
+                <line x1="25" y1="25" x2="25" y2="75" stroke="#5b4cdb" stroke-width="3"/>
+                <line x1="75" y1="25" x2="75" y2="75" stroke="#5b4cdb" stroke-width="3"/>
+            </svg>
+            <p class="mt-4 text-white font-semibold loader-text">Cuadril<span class="gradient-text">IA</span></p>
+        </div>
+    </div>
     <!-- Skip to content link for keyboard/screen reader users -->
     <a href="#main-content" class="skip-link">
         Saltar al contenido principal
@@ -666,6 +715,14 @@
 
         backToTopBtn.addEventListener('click', () => {
             window.scrollTo({ top: 0, behavior: 'smooth' });
+        });
+
+        // Page loader - hide when page is ready
+        const pageLoader = document.getElementById('page-loader');
+        window.addEventListener('load', () => {
+            setTimeout(() => {
+                pageLoader.classList.add('hidden');
+            }, 300); // Small delay for smoother transition
         });
     </script>
 


### PR DESCRIPTION
## Summary
- Add branded loading animation that shows while page loads
- Smooth fade-out transition when content is ready

## Changes
- Added page loader overlay with CuadrilIA logo
- Pulsing animation on logo during load
- Fading text animation
- JavaScript to hide loader on window.load event

Closes #20