### PR TITLE
feat(content): add badges/certifications section

### DIFF
--- a/index.html
+++ b/index.html
@@ -366,6 +366,57 @@
         </div>
     </section>
 
+    <!-- Badges / Certificaciones -->
+    <section class="py-16 px-4">
+        <div class="max-w-5xl mx-auto">
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-6 md:gap-8">
+                <!-- Badge 1: Formadores Certificados -->
+                <div class="fade-in text-center p-6 rounded-2xl bg-gray-800/20 border border-gray-700/50 hover:border-purple-500/30 transition-colors">
+                    <div class="w-16 h-16 mx-auto mb-4 rounded-full bg-gradient-to-br from-purple-600/20 to-blue-600/20 flex items-center justify-center">
+                        <svg class="w-8 h-8 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z"/>
+                        </svg>
+                    </div>
+                    <p class="font-semibold text-white mb-1">Formadores Certificados</p>
+                    <p class="text-gray-400 text-sm">Expertos en IA generativa</p>
+                </div>
+                
+                <!-- Badge 2: +50 Empresas -->
+                <div class="fade-in text-center p-6 rounded-2xl bg-gray-800/20 border border-gray-700/50 hover:border-purple-500/30 transition-colors">
+                    <div class="w-16 h-16 mx-auto mb-4 rounded-full bg-gradient-to-br from-purple-600/20 to-blue-600/20 flex items-center justify-center">
+                        <svg class="w-8 h-8 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
+                        </svg>
+                    </div>
+                    <p class="font-semibold text-white mb-1">+50 Empresas</p>
+                    <p class="text-gray-400 text-sm">Han confiado en nosotros</p>
+                </div>
+                
+                <!-- Badge 3: 100% Práctico -->
+                <div class="fade-in text-center p-6 rounded-2xl bg-gray-800/20 border border-gray-700/50 hover:border-purple-500/30 transition-colors">
+                    <div class="w-16 h-16 mx-auto mb-4 rounded-full bg-gradient-to-br from-purple-600/20 to-blue-600/20 flex items-center justify-center">
+                        <svg class="w-8 h-8 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/>
+                        </svg>
+                    </div>
+                    <p class="font-semibold text-white mb-1">100% Práctico</p>
+                    <p class="text-gray-400 text-sm">Aprende haciendo</p>
+                </div>
+                
+                <!-- Badge 4: Soporte Continuo -->
+                <div class="fade-in text-center p-6 rounded-2xl bg-gray-800/20 border border-gray-700/50 hover:border-purple-500/30 transition-colors">
+                    <div class="w-16 h-16 mx-auto mb-4 rounded-full bg-gradient-to-br from-purple-600/20 to-blue-600/20 flex items-center justify-center">
+                        <svg class="w-8 h-8 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M18.364 5.636l-3.536 3.536m0 5.656l3.536 3.536M9.172 9.172L5.636 5.636m3.536 9.192l-3.536 3.536M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-5 0a4 4 0 11-8 0 4 4 0 018 0z"/>
+                        </svg>
+                    </div>
+                    <p class="font-semibold text-white mb-1">Soporte Continuo</p>
+                    <p class="text-gray-400 text-sm">Te acompañamos siempre</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <!-- Servicios -->
     <section id="servicios" class="py-24 px-4">
         <div class="max-w-7xl mx-auto">


### PR DESCRIPTION
## Summary
- Add trust badges section to build credibility
- Positioned between logo marquee and services

## Badges
1. **Formadores Certificados** - Expert credentials
2. **+50 Empresas** - Social proof
3. **100% Práctico** - Methodology highlight
4. **Soporte Continuo** - Ongoing support

## Changes
- 4-column responsive grid (2 cols mobile, 4 desktop)
- Icons with gradient backgrounds
- Subtle hover effects

Closes #23