### PR TITLE
Update contact email from info@cuadril.es to hola@cuadril.es

### DIFF
--- a/aviso-legal.html
+++ b/aviso-legal.html
@@ -75,7 +75,7 @@
                         <li><strong>Forma jurídica:</strong> <span class="text-yellow-400">[POR COMPLETAR]</span> (Emprendedor Individual / S.L. / S.A.)</li>
                         <li><strong>CIF/NIF:</strong> <span class="text-yellow-400">[POR COMPLETAR]</span></li>
                         <li><strong>Domicilio social:</strong> <span class="text-yellow-400">[POR COMPLETAR]</span></li>
-                        <li><strong>Correo electrónico:</strong> <a href="mailto:info@cuadril.es" class="text-purple-400 hover:text-purple-300">info@cuadril.es</a></li>
+                        <li><strong>Correo electrónico:</strong> <a href="mailto:hola@cuadril.es" class="text-purple-400 hover:text-purple-300">hola@cuadril.es</a></li>
                         <li><strong>Teléfono:</strong> <span class="text-yellow-400">[POR COMPLETAR]</span></li>
                     </ul>
                     <p class="text-yellow-400 text-sm mt-4 italic">⚠️ Los campos marcados deben ser completados por el propietario del sitio.</p>
@@ -203,7 +203,7 @@
                 <div class="bg-gray-800/30 border border-gray-700 rounded-xl p-6">
                     <p class="text-gray-300 mb-4">Para cualquier consulta legal, duda o reclamación, puedes contactarnos a través de:</p>
                     <div class="space-y-3">
-                        <p class="text-gray-300"><strong>Email:</strong> <a href="mailto:info@cuadril.es" class="text-purple-400 hover:text-purple-300 text-xl">info@cuadril.es</a></p>
+                        <p class="text-gray-300"><strong>Email:</strong> <a href="mailto:hola@cuadril.es" class="text-purple-400 hover:text-purple-300 text-xl">hola@cuadril.es</a></p>
                         <p class="text-gray-300"><strong>Ubicación:</strong> Pamplona, Navarra, España</p>
                     </div>
                     <div class="mt-4 bg-blue-900/20 border border-blue-500/30 rounded-lg p-4">

--- a/privacidad.html
+++ b/privacidad.html
@@ -71,7 +71,7 @@
                 <h2 id="responsable" class="text-2xl font-bold mb-4">1. Responsable del Tratamiento</h2>
                 <div class="bg-gray-800/30 border border-gray-700 rounded-xl p-6">
                     <p class="text-gray-300 mb-2"><strong>Nombre del responsable:</strong> CuadrilIA</p>
-                    <p class="text-gray-300 mb-2"><strong>Correo electrónico:</strong> <a href="mailto:info@cuadril.es" class="text-purple-400 hover:text-purple-300">info@cuadril.es</a></p>
+                    <p class="text-gray-300 mb-2"><strong>Correo electrónico:</strong> <a href="mailto:hola@cuadril.es" class="text-purple-400 hover:text-purple-300">hola@cuadril.es</a></p>
                     <p class="text-gray-300"><strong>Ubicación:</strong> Pamplona, Navarra, España</p>
                 </div>
             </section>
@@ -197,7 +197,7 @@
                     <h3 class="text-lg font-semibold mb-4 text-purple-400">¿Cómo ejercer tus derechos?</h3>
                     <p class="text-gray-300 mb-4">Envía tu solicitud por email a:</p>
                     <p class="text-center text-xl mb-4">
-                        <a href="mailto:info@cuadril.es" class="text-purple-400 hover:text-purple-300 font-semibold">info@cuadril.es</a>
+                        <a href="mailto:hola@cuadril.es" class="text-purple-400 hover:text-purple-300 font-semibold">hola@cuadril.es</a>
                     </p>
                     <ul class="list-disc list-inside text-gray-300 space-y-2 ml-4">
                         <li><strong>Tiempo de respuesta:</strong> 1 mes (ampliable hasta 2 meses en casos complejos)</li>

--- a/solicitud-datos.html
+++ b/solicitud-datos.html
@@ -363,7 +363,7 @@ Enviado desde: https://cuadril.es/solicitud-datos
 Fecha: ${new Date().toLocaleDateString('es-ES')}
             `.trim();
 
-            const mailtoLink = `mailto:info@cuadril.es?subject=Solicitud%20GDPR%20-%20${encodeURIComponent(typeLabels[requestType] || requestType)}&body=${encodeURIComponent(emailBody)}`;
+            const mailtoLink = `mailto:hola@cuadril.es?subject=Solicitud%20GDPR%20-%20${encodeURIComponent(typeLabels[requestType] || requestType)}&body=${encodeURIComponent(emailBody)}`;
 
             alert('Se abrirá tu cliente de correo para enviar la solicitud. Por favor, revisa el contenido antes de enviar.');
             window.location.href = mailtoLink;


### PR DESCRIPTION
## Summary

Updates the contact email address across all legal and contact pages from `info@cuadril.es` to `hola@cuadril.es`.

## Changes Made

### Files Modified (3 files, 5 occurrences)

1. **solicitud-datos.html** (1 change)
   - Line 366: Updated mailto link in GDPR request functionality
   - Changed: `mailto:info@cuadril.es` → `mailto:hola@cuadril.es`

2. **aviso-legal.html** (2 changes)
   - Line 78: Updated contact email in legal notice section
   - Line 206: Updated contact email in footer section

3. **privacidad.html** (2 changes)
   - Line 74: Updated contact email in privacy policy
   - Line 200: Updated contact email in DPO (Data Protection Officer) section

## Testing

- [x] All mailto links updated correctly
- [x] GDPR request email generation uses new address
- [x] No broken links or references remaining
- [x] Consistency across all legal pages maintained

## Impact

- **Low risk**: Simple text replacement
- **No functionality changes**: Only email address updates
- **Improved branding**: Aligns with preferred contact email naming convention

## Related Issue

Closes #59